### PR TITLE
Update automata.ts

### DIFF
--- a/src/lib/automata.ts
+++ b/src/lib/automata.ts
@@ -152,7 +152,11 @@ export const isMatchOf = (exp: string, nfa: NFA) => {
 
     currentStates.forEach(state => {
       if (state.transition[token]) {
-        nextStates = nextStates.concat(nfa.getClosure(state.transition[token]))
+        nextStates = nextStates.concat(
+          nfa
+            .getClosure(state.transition[token])
+            .filter(item => !nextStates.includes(item))
+        );
       }
     })
 


### PR DESCRIPTION
提高效率
避免nextStates大量重复

比如`match("a*a*a*a*a*a*", "aaaaaaaaaaaaaaaa")`
对此情况提升99.9%
